### PR TITLE
API.MD added so that I can push

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50167,7 +50167,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.11.0",

--- a/packages/rest-api-construct/API.md
+++ b/packages/rest-api-construct/API.md
@@ -4,6 +4,18 @@
 
 ```ts
 
+import { Construct } from 'constructs';
+
+// @public
+export class AmplifyConstruct extends Construct {
+    constructor(scope: Construct, id: string, props?: ConstructCognitoProps);
+}
+
+// @public (undocumented)
+export type ConstructCognitoProps = {
+    includeQueue?: boolean;
+};
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/rest-api-construct/src/types.ts
+++ b/packages/rest-api-construct/src/types.ts
@@ -1,8 +1,22 @@
+import * as lamb from 'aws-cdk-lib/aws-lambda';
+
+//defines 4 potential sources for Lambda function
+export type ExistingDirectory = { path: string };
+export type ExistingLambda = { id: string; name: string };
+export type NewFromCode = { code: string };
+export type NewFromTemplate = { template: string };
+
+//adds runtime to the source
+type LambdaSource = {
+  runtime: lamb.Runtime;
+  source: ExistingDirectory | ExistingLambda | NewFromCode | NewFromTemplate;
+};
+
 export type RestApiConstructProps = {
   apiName: string;
   path: string;
   routes: HttpMethod[];
-  lambdaEntry: string;
+  lambdaEntry: LambdaSource;
 };
 
 export type HttpMethod =


### PR DESCRIPTION
## Problem
- Unable to push getting the error: Expected no API.md file updates but found packages/rest-api-construct/API.md
Run 'npm run update:api' and commit the updates to fix.
- Lambda was a simple string path

## Changes
- Form generator version auto updated in package-lock.json
- Ran npm run update:api as instructed by the terminal to be allowed to push, which generated API.MD for the new package
- Added more lambda selection options (new from template, existing from file, existing from aws, new from scratch) 

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
