### PR TITLE
Lambda - create folder/files for new function

### DIFF
--- a/packages/rest-api-construct/API.md
+++ b/packages/rest-api-construct/API.md
@@ -31,6 +31,7 @@ export type LambdaSource = {
 // @public (undocumented)
 export type NewFromCode = {
     code: string;
+    functionName: string;
 };
 
 // @public

--- a/packages/rest-api-construct/API.md
+++ b/packages/rest-api-construct/API.md
@@ -50,7 +50,7 @@ export type RestApiConstructProps = {
 // @public (undocumented)
 export type RestApiPathConfig = {
     path: string;
-    routes: HttpMethod[];
+    methods: HttpMethod[];
     lambdaEntry: LambdaSource;
 };
 

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -3,6 +3,8 @@ import { RestApiConstruct } from './construct.js';
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { strictEqual } from 'assert';
+import * as fs from 'fs';
 
 void describe('RestApiConstruct Lambda Handling', () => {
   void it('loads an existing local lambda function if the directory is specified', () => {
@@ -39,6 +41,7 @@ void describe('RestApiConstruct Lambda Handling', () => {
           lambdaEntry: {
             runtime: lambda.Runtime.NODEJS_22_X,
             source: {
+              functionName: 'MyFunction1',
               code: "export const handler = () => {return 'Hello World! This is a new lambda function.';};",
             },
           },
@@ -50,38 +53,113 @@ void describe('RestApiConstruct Lambda Handling', () => {
       Handler: 'index.handler',
     });
   });
-});
 
-void describe('RestApiConstruct', () => {
-  void it('creates a queue if specified', () => {
+  void it('creates local files for a new function if the code is specified', () => {
+    //delete folder amplify/functions/MyFunction2 first if the test has failed
+
+    //function files should not originally exist
+    let src = process.cwd();
+    src += '/amplify/functions/MyFunction2/';
+    strictEqual(fs.existsSync(src + 'resource.ts'), false);
+    strictEqual(fs.existsSync(src + 'handler.ts'), false);
+
+    //create the api containing a new lambda from source code
     const app = new App();
     const stack = new Stack(app);
-    new RestApiConstruct(stack, 'RestApiTest', {
-      apiName: 'RestApiTest',
+    new RestApiConstruct(stack, 'RestApiNewLambda2', {
+      apiName: 'RestApiNewLambda2',
       apiProps: [
         {
-          path: '/test',
-          routes: ['GET', 'POST'],
+          path: 'items',
+          routes: ['GET'],
           lambdaEntry: {
-            runtime: lambda.Runtime.NODEJS_18_X,
+            runtime: lambda.Runtime.NODEJS_22_X,
             source: {
-              path: './test-lambda',
-            },
-          },
-        },
-        {
-          path: '/blog',
-          routes: ['GET', 'POST', 'PUT'],
-          lambdaEntry: {
-            runtime: lambda.Runtime.NODEJS_18_X,
-            source: {
-              path: './blog-lambda',
+              functionName: 'MyFunction2',
+              code: "export const handler = () => {return 'Hello World! This is a new lambda function.';};",
             },
           },
         },
       ],
     });
-    const template = Template.fromStack(stack);
-    template.resourceCountIs('AWS::AGW::RestApi', 1);
+
+    //function files should have been created
+    strictEqual(fs.existsSync(src + 'resource.ts'), true);
+    strictEqual(fs.existsSync(src + 'handler.ts'), true);
   });
+
+  //   void it("loads a function from aws if the id and name are specified", () => {
+  //     const app = new App();
+  //     const funcStack = new Stack(app, "funcStack");
+
+  //     const func = new lambda.Function(funcStack, "testFunc", {
+  //         runtime: lambda.Runtime.NODEJS_22_X,
+  //         handler: 'index.handler',
+  //         code: lambda.Code.fromInline("export const handler = () => {return 'Hello World! This is an existing lambda function.';};")
+  //     });
+
+  //     const stack = new Stack(app, "stack");
+  //     new RestApiConstruct(stack, 'RestApiLoadFunc', {
+  //         apiName: 'RestApiLoad',
+  //         apiProps: [{
+  //             path: 'stuff',
+  //             routes: ['GET'],
+  //             lambdaEntry: {
+  //                 runtime: lambda.Runtime.NODEJS_22_X,
+  //                 source: {id: func.functionArn, name: func.functionName}
+  //             }
+  //         }]
+  //     });
+
+  // const template = Template.fromStack(stack);
+  // //there should be no functions in the stack
+  // template.resourcePropertiesCountIs('AWS::Lambda::Function', {Arn: func.functionArn}, 0);
+  // //should be allowed to call the function
+  // template.hasResourceProperties('AWS::Lambda::Permission', {
+  //     Action: 'lambda:InvokeFunction',
+  //     Principal: 'apigateway.amazonaws.com',
+  //     FunctionName: {"Fn::GetAtt": [func.functionName, "Arn"]},
+  // });
+  //api should reference ARN
+  //     template.hasResourceProperties('AWS::ApiGateway::Method', {
+  //         Integration: {Uri: {'Fn::Sub': [
+  //             'arn:aws:apigateway:${AWS::REGION}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations',
+  //             {LambdaArn: func.functionArn}
+  //         ]}}
+  //     })
 });
+// });
+
+// void describe('RestApiConstruct', () => {
+//   void it('creates a queue if specified', () => {
+//     const app = new App();
+//     const stack = new Stack(app);
+//     new RestApiConstruct(stack, 'RestApiTest', {
+//       apiName: 'RestApiTest',
+//       apiProps: [
+//         {
+//           path: '/test',
+//           routes: ['GET', 'POST'],
+//           lambdaEntry: {
+//             runtime: lambda.Runtime.NODEJS_18_X,
+//             source: {
+//               path: './test-lambda',
+//             },
+//           },
+//         },
+//         {
+//           path: '/blog',
+//           routes: ['GET', 'POST', 'PUT'],
+//           lambdaEntry: {
+//             runtime: lambda.Runtime.NODEJS_18_X,
+//             source: {
+//               path: './blog-lambda',
+//             },
+//           },
+//         },
+//       ],
+//     });
+//     const template = Template.fromStack(stack);
+//     template.resourceCountIs('AWS::AGW::RestApi', 1);
+//   });
+// });

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -71,7 +71,7 @@ void describe('RestApiConstruct Lambda Handling', () => {
       apiProps: [
         {
           path: 'items',
-          routes: ['GET'],
+          methods: ['GET'],
           lambdaEntry: {
             runtime: lambda.Runtime.NODEJS_22_X,
             source: {
@@ -106,7 +106,7 @@ void describe('RestApiConstruct Lambda Handling', () => {
       apiProps: [
         {
           path: 'stuff',
-          routes: ['GET'],
+          methods: ['GET'],
           lambdaEntry: {
             runtime: lambda.Runtime.NODEJS_22_X,
             source: { id: func.functionArn, name: func.functionName },

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -88,78 +88,90 @@ void describe('RestApiConstruct Lambda Handling', () => {
     strictEqual(fs.existsSync(src + 'handler.ts'), true);
   });
 
-  //   void it("loads a function from aws if the id and name are specified", () => {
-  //     const app = new App();
-  //     const funcStack = new Stack(app, "funcStack");
+  void it('loads a function from aws if the id and name are specified', () => {
+    const app = new App();
+    const funcStack = new Stack(app, 'funcStack');
 
-  //     const func = new lambda.Function(funcStack, "testFunc", {
-  //         runtime: lambda.Runtime.NODEJS_22_X,
-  //         handler: 'index.handler',
-  //         code: lambda.Code.fromInline("export const handler = () => {return 'Hello World! This is an existing lambda function.';};")
-  //     });
+    const func = new lambda.Function(funcStack, 'testFunc', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        "export const handler = () => {return 'Hello World! This is an existing lambda function.';};",
+      ),
+    });
 
-  //     const stack = new Stack(app, "stack");
-  //     new RestApiConstruct(stack, 'RestApiLoadFunc', {
-  //         apiName: 'RestApiLoad',
-  //         apiProps: [{
-  //             path: 'stuff',
-  //             routes: ['GET'],
-  //             lambdaEntry: {
-  //                 runtime: lambda.Runtime.NODEJS_22_X,
-  //                 source: {id: func.functionArn, name: func.functionName}
-  //             }
-  //         }]
-  //     });
+    const stack = new Stack(app, 'stack');
+    new RestApiConstruct(stack, 'RestApiLoadFunc', {
+      apiName: 'RestApiLoad',
+      apiProps: [
+        {
+          path: 'stuff',
+          routes: ['GET'],
+          lambdaEntry: {
+            runtime: lambda.Runtime.NODEJS_22_X,
+            source: { id: func.functionArn, name: func.functionName },
+          },
+        },
+      ],
+    });
 
-  // const template = Template.fromStack(stack);
-  // //there should be no functions in the stack
-  // template.resourcePropertiesCountIs('AWS::Lambda::Function', {Arn: func.functionArn}, 0);
-  // //should be allowed to call the function
-  // template.hasResourceProperties('AWS::Lambda::Permission', {
-  //     Action: 'lambda:InvokeFunction',
-  //     Principal: 'apigateway.amazonaws.com',
-  //     FunctionName: {"Fn::GetAtt": [func.functionName, "Arn"]},
-  // });
-  //api should reference ARN
-  //     template.hasResourceProperties('AWS::ApiGateway::Method', {
-  //         Integration: {Uri: {'Fn::Sub': [
-  //             'arn:aws:apigateway:${AWS::REGION}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations',
-  //             {LambdaArn: func.functionArn}
-  //         ]}}
-  //     })
+    const template = Template.fromStack(stack);
+    //there should be no functions in the stack
+    template.resourcePropertiesCountIs(
+      'AWS::Lambda::Function',
+      { Arn: func.functionArn },
+      0,
+    );
+    //should be allowed to call the function
+    template.hasResourceProperties('AWS::Lambda::Permission', {
+      Action: 'lambda:InvokeFunction',
+      Principal: 'apigateway.amazonaws.com',
+      FunctionName: { 'Fn::GetAtt': [func.functionName, 'Arn'] },
+    });
+    //api should reference ARN
+    template.hasResourceProperties('AWS::ApiGateway::Method', {
+      Integration: {
+        Uri: {
+          'Fn::Sub': [
+            'arn:aws:apigateway:${AWS::REGION}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations',
+            { LambdaArn: func.functionArn },
+          ],
+        },
+      },
+    });
+  });
 });
-// });
 
-// void describe('RestApiConstruct', () => {
-//   void it('creates a queue if specified', () => {
-//     const app = new App();
-//     const stack = new Stack(app);
-//     new RestApiConstruct(stack, 'RestApiTest', {
-//       apiName: 'RestApiTest',
-//       apiProps: [
-//         {
-//           path: '/test',
-//           routes: ['GET', 'POST'],
-//           lambdaEntry: {
-//             runtime: lambda.Runtime.NODEJS_18_X,
-//             source: {
-//               path: './test-lambda',
-//             },
-//           },
-//         },
-//         {
-//           path: '/blog',
-//           routes: ['GET', 'POST', 'PUT'],
-//           lambdaEntry: {
-//             runtime: lambda.Runtime.NODEJS_18_X,
-//             source: {
-//               path: './blog-lambda',
-//             },
-//           },
-//         },
-//       ],
-//     });
-//     const template = Template.fromStack(stack);
-//     template.resourceCountIs('AWS::AGW::RestApi', 1);
-//   });
-// });
+void describe('RestApiConstruct', () => {
+  void it('creates a queue if specified', () => {
+    const app = new App();
+    const stack = new Stack(app);
+    new RestApiConstruct(stack, 'RestApiTest', {
+      apiName: 'RestApiTest',
+      apiProps: [
+        {
+          path: '/test',
+          routes: ['GET', 'POST'],
+          lambdaEntry: {
+            runtime: lambda.Runtime.NODEJS_18_X,
+            source: {
+              path: './test-lambda',
+            },
+          },
+        },
+        {
+          path: '/blog',
+          routes: ['GET', 'POST', 'PUT'],
+          lambdaEntry: {
+            runtime: lambda.Runtime.NODEJS_18_X,
+            source: {
+              path: './blog-lambda',
+            },
+          },
+        },
+      ],
+    });
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::AGW::RestApi', 1);
+  });
+});

--- a/packages/rest-api-construct/src/construct.ts
+++ b/packages/rest-api-construct/src/construct.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apiGateway from 'aws-cdk-lib/aws-apigateway';
+import * as fs from 'fs';
 import {
   ExistingDirectory,
   ExistingLambda,
@@ -35,7 +36,41 @@ export class RestApiConstruct extends Construct {
         const src = source as ExistingDirectory;
         code = lambda.Code.fromAsset(src.path);
       } else if ('code' in source) {
+        //create local files containing the new function
         const src = source as NewFromCode;
+
+        let resourceFile = null;
+        let handlerFile = null;
+        try {
+          //ensure <project>/amplify/functions/<functionName> directory exists
+          const pathToFunctionFiles =
+            process.cwd() + '/amplify/functions/' + src.functionName;
+          fs.mkdirSync(pathToFunctionFiles, { recursive: true });
+          //create resource.ts, unless it already exists, in which case, it will error and exit (wx flag)
+          resourceFile = fs.openSync(
+            pathToFunctionFiles + '/resource.ts',
+            'wx',
+          );
+          const code =
+            "import { defineFunction } from '@aws-amplify/backend';\n" +
+            `export const ${src.functionName} = defineFunction({\n` +
+            `  name: '${src.functionName}',\n` +
+            "  entry: './handler.ts'\n" +
+            '});';
+          fs.writeSync(resourceFile, Buffer.from(code));
+          //create handler.ts only if it doesn't already exist
+          handlerFile = fs.openSync(pathToFunctionFiles + '/handler.ts', 'wx');
+          fs.writeSync(handlerFile, Buffer.from(src.code));
+        } catch (err) {
+          if (err instanceof Error)
+            throw Error(
+              `Unable to create ${src.functionName}:\n${err.message}`,
+            );
+        } finally {
+          if (resourceFile != null) fs.closeSync(resourceFile);
+          if (handlerFile != null) fs.closeSync(handlerFile);
+        }
+
         code = lambda.Code.fromInline(src.code);
       }
       //if none of these are true, it's a ExistingLambda type, handled below
@@ -45,6 +80,7 @@ export class RestApiConstruct extends Construct {
       if ('id' in source) {
         const src = source as ExistingLambda;
         handler = lambda.Function.fromFunctionName(this, src.id, src.name);
+        //TODO: do we need to grant the rest api permission to call the lambda?
       } else {
         handler = new lambda.Function(this, `LambdaHandler-${index}`, {
           runtime: lambdaEntry.runtime,
@@ -65,6 +101,7 @@ export class RestApiConstruct extends Construct {
    * Adds nested resources to the API based on the provided path.
    */
   private addNestedResource(
+    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /
     root: apiGateway.IResource,
     path: string,
   ): apiGateway.IResource {

--- a/packages/rest-api-construct/src/types.ts
+++ b/packages/rest-api-construct/src/types.ts
@@ -3,7 +3,7 @@ import * as lamb from 'aws-cdk-lib/aws-lambda';
 //defines 3 potential sources for Lambda function
 export type ExistingDirectory = { path: string };
 export type ExistingLambda = { id: string; name: string };
-export type NewFromCode = { code: string };
+export type NewFromCode = { code: string; functionName: string };
 
 //adds runtime to the source
 export type LambdaSource = {


### PR DESCRIPTION
As discussed, this adds a feature to create a folder within amplify/functions/ with the same name as the function, resource.ts, and handler.ts which contains the source code, when the rest api handler is a new function from source code. This also adds a unit test.

Because the feature actually creates the files, the unit test will fail if the amplify/functions/<FunctionName> folder is not deleted, because it shouldn't overwrite an existing function, so it would fail to create the files. I'm considering adding a feature to pass a directory where the files should be saved, so testing could pass a different testing directory and clean up before/after the test.

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
