### PR TITLE
Path validation

### DIFF
--- a/.changeset/moody-bushes-heal.md
+++ b/.changeset/moody-bushes-heal.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/rest-api-construct': patch
+---
+
+Adds error handling and a unit test for invalid REST API paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -12504,7 +12504,6 @@
     },
     "node_modules/@aws-cdk/cx-api/node_modules/semver": {
       "version": "7.7.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -46345,7 +46344,6 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -46354,7 +46352,6 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -46659,7 +46656,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend": "^1.16.1",
-        "@aws-amplify/backend-output-storage": "^1.3.1"
+        "@aws-amplify/backend-output-storage": "^1.3.1",
+        "@aws-amplify/platform-core": "^1.10.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.189.0",

--- a/packages/rest-api-construct/package.json
+++ b/packages/rest-api-construct/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/backend": "^1.16.1",
-    "@aws-amplify/backend-output-storage": "^1.3.1"
+    "@aws-amplify/backend-output-storage": "^1.3.1",
+    "@aws-amplify/platform-core": "^1.10.0"
   }
 }

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -9,37 +9,67 @@ import {
   StackResolverStub,
 } from '@aws-amplify/backend-platform-test-stubs';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
+import assert from 'node:assert';
+import { RestApiPathConfig } from './types.js';
+
+const setupExampleLambda = (stack: Stack) => {
+  const factory = defineFunction({
+    name: 'Test Function',
+    entry: './test-assets/handler.ts',
+  });
+
+  //stubs for the instance props
+  const constructContainer = new ConstructContainerStub(
+    new StackResolverStub(stack),
+  );
+  const outputStorageStrategy = new StackMetadataBackendOutputStorageStrategy(
+    stack,
+  );
+  const resourceNameValidator = new ResourceNameValidatorStub();
+  const getInstanceProps: ConstructFactoryGetInstanceProps = {
+    constructContainer,
+    outputStorageStrategy,
+    resourceNameValidator,
+  };
+
+  return factory.getInstance(getInstanceProps);
+};
+
+const constructApiWithPath = (path: string, n: number = 1) => {
+  if (n < 0) n = 0;
+  const stack = new Stack(new App());
+  const resource = setupExampleLambda(stack);
+  if (n == 0)
+    return new RestApiConstruct(stack, 'testApi0', {
+      apiName: 'testApi0',
+      apiProps: [],
+    });
+  const apiProp: RestApiPathConfig = {
+    lambdaEntry: resource,
+    methods: [{ method: 'GET', authorizer: { type: 'none' } }],
+    path: path,
+  };
+  const apiProps: RestApiPathConfig[] = [];
+  for (let x = 0; x < n; x++) {
+    apiProps.push(apiProp);
+  }
+  return new RestApiConstruct(stack, 'testApi1', {
+    apiName: 'testApi1',
+    apiProps: apiProps,
+  });
+};
 
 void describe('RestApiConstruct Lambda Handling', () => {
   void it('integrates the result of defineFunction into the api', () => {
     const app = new App();
     const stack = new Stack(app);
-    const factory = defineFunction({
-      name: 'Test Function',
-      entry: './test-assets/handler.ts',
-    });
-
-    //stubs for the instance props
-    const constructContainer = new ConstructContainerStub(
-      new StackResolverStub(stack),
-    );
-    const outputStorageStrategy = new StackMetadataBackendOutputStorageStrategy(
-      stack,
-    );
-    const resourceNameValidator = new ResourceNameValidatorStub();
-    const getInstanceProps: ConstructFactoryGetInstanceProps = {
-      constructContainer,
-      outputStorageStrategy,
-      resourceNameValidator,
-    };
-
-    const resource = factory.getInstance(getInstanceProps);
+    const resource = setupExampleLambda(stack);
 
     new RestApiConstruct(stack, 'RestApiTest', {
       apiName: 'RestApiTest',
       apiProps: [
         {
-          path: 'items',
+          path: '/items',
           lambdaEntry: resource,
           methods: [
             {
@@ -50,6 +80,35 @@ void describe('RestApiConstruct Lambda Handling', () => {
         },
       ],
     });
+  });
+});
+
+void describe('RestApiConstruct Error Handling', () => {
+  void it('throws an error if any of the rest api paths are invalid', () => {
+    assert.throws(
+      () => constructApiWithPath('no/leading/slash'),
+      'NoLeadingSlashError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/an/ending/slash/'),
+      'TrailingSlashError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/a/double//slash'),
+      'DoubleSlashError',
+    );
+    assert.throws(() => constructApiWithPath(''), 'EmptyPathError');
+
+    assert.throws(
+      () => constructApiWithPath('/no/paths/provided', 0),
+      'NoPathsError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/a/duplicate', 2),
+      'DuplicatePathError',
+    );
+
+    assert.doesNotThrow(() => constructApiWithPath('/a/valid/path'));
   });
 });
 

--- a/packages/rest-api-construct/src/construct.ts
+++ b/packages/rest-api-construct/src/construct.ts
@@ -45,10 +45,10 @@ export class RestApiConstruct extends Construct {
     root: apiGateway.IResource,
     path: string,
   ): apiGateway.IResource {
-    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /items/stuff/
+    //remove the leading slash to prevent empty id error
     if (path.startsWith('/')) path = path.substring(1);
-    // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
 
+    // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
     const parts = path.split('/');
 
     // Traverse the path, adding any missing nested resources along the way

--- a/packages/rest-api-construct/src/construct.ts
+++ b/packages/rest-api-construct/src/construct.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import * as apiGateway from 'aws-cdk-lib/aws-apigateway';
 import { RestApiConstructProps } from './types.js';
+import { validateRestApiPaths } from './validate_paths.js';
 
 /**
  * Rest API construct for Amplify Backend
@@ -12,6 +13,11 @@ export class RestApiConstruct extends Construct {
    */
   constructor(scope: Construct, id: string, props: RestApiConstructProps) {
     super(scope, id);
+
+    //check that the paths are valid before creating the API
+    const paths: string[] = [];
+    props.apiProps.forEach((value) => paths.push(value.path));
+    validateRestApiPaths(paths);
 
     // Create a new API Gateway REST API with the specified name
     this.api = new apiGateway.RestApi(this, 'RestApi', {
@@ -39,8 +45,10 @@ export class RestApiConstruct extends Construct {
     root: apiGateway.IResource,
     path: string,
   ): apiGateway.IResource {
-    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /
+    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /items/stuff/
+    if (path.startsWith('/')) path = path.substring(1);
     // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
+
     const parts = path.split('/');
 
     // Traverse the path, adding any missing nested resources along the way

--- a/packages/rest-api-construct/src/validate_paths.ts
+++ b/packages/rest-api-construct/src/validate_paths.ts
@@ -1,0 +1,57 @@
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+
+/**
+ * Validates REST API paths, ensuring a leading slash, no trailing slash, and no double slashes.
+ * If all paths are valid, nothing will happen; otherwise an error will be thrown.
+ * @param paths array of all the paths to be validated
+ */
+export const validateRestApiPaths = (paths: string[]) => {
+  if (paths.length == 0) {
+    throw new AmplifyUserError<string>('NoPathsError', {
+      message: 'There must be at least one path.',
+      resolution: 'Add at least one valid path.',
+    });
+  }
+  const pathCount: { [path: string]: number } = {};
+  paths.forEach((value) => {
+    validatePath(value);
+    if (pathCount[value]) {
+      throw new AmplifyUserError<string>('DuplicatePathError', {
+        message:
+          'Rest API paths must be unique. Found duplicate path: ' + value,
+        resolution: 'Remove duplicates of the path, leaving only one.',
+      });
+    } else {
+      pathCount[value] = 1;
+    }
+  });
+};
+
+const validatePath = (path: string) => {
+  if (path === '') {
+    throw new AmplifyUserError<string>('EmptyPathError', {
+      message: 'A path must not be an empty string.',
+      resolution: 'Replace any empty string paths with valid paths.',
+    });
+  }
+  if (!path.startsWith('/')) {
+    throw new AmplifyUserError<string>('NoLeadingSlashError', {
+      message: "Rest API paths must start with '/'. Found path: " + path,
+      resolution: "Add '/' to the start of your path.",
+    });
+  }
+
+  if (path.endsWith('/')) {
+    throw new AmplifyUserError<string>('TrailingSlashError', {
+      message: "Rest API paths must not end with '/'. Found path: " + path,
+      resolution: "Remove '/' from the end of your path.",
+    });
+  }
+
+  if (path.includes('//')) {
+    throw new AmplifyUserError<string>('DoubleSlashError', {
+      message: "Rest API paths must not contain '//'. Found path: " + path,
+      resolution: "Replace '//' with '/' in your path.",
+    });
+  }
+};

--- a/packages/rest-api-construct/tsconfig.json
+++ b/packages/rest-api-construct/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
     { "path": "../backend" },
-    { "path": "../backend-output-storage" }
+    { "path": "../backend-output-storage" },
+    { "path": "../platform-core" }
   ]
 }


### PR DESCRIPTION
## Problem
The RestApiConstruct allowed users to enter invalid REST API paths, leading to errors

## Changes
Adds a file that validates a given array of paths
Adds a call to validate the paths within the construct
Adds unit test and updates older unit test to work with the new requirements
Removes the leading slash in the path to prevent empty ID error in addNestedResource

## Validation
Unit test added and is passing

## Checklist
- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._