### PR TITLE
Check package versions

### DIFF
--- a/.changeset/moody-bushes-heal.md
+++ b/.changeset/moody-bushes-heal.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/rest-api-construct': patch
+---
+
+Adds error handling and a unit test for invalid REST API paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -46640,7 +46640,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.189.0",
+        "aws-cdk-lib": "^2.189.1",
         "constructs": "^10.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12504,7 +12504,6 @@
     },
     "node_modules/@aws-cdk/cx-api/node_modules/semver": {
       "version": "7.7.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -46345,7 +46344,6 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -46354,7 +46352,6 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -46659,7 +46656,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend": "^1.16.1",
-        "@aws-amplify/backend-output-storage": "^1.3.1"
+        "@aws-amplify/backend-output-storage": "^1.3.1",
+        "@aws-amplify/platform-core": "^1.10.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.189.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31534,7 +31534,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -32214,7 +32213,8 @@
     },
     "node_modules/aws-lambda": {
       "version": "1.0.7",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.814.0",
@@ -32228,12 +32228,10 @@
     },
     "node_modules/aws-lambda/node_modules/commander": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/aws-sdk": {
       "version": "2.1692.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -32264,7 +32262,6 @@
     },
     "node_modules/aws-sdk/node_modules/buffer": {
       "version": "4.9.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -32274,7 +32271,6 @@
     },
     "node_modules/aws-sdk/node_modules/events": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
@@ -32282,17 +32278,14 @@
     },
     "node_modules/aws-sdk/node_modules/ieee754": {
       "version": "1.1.13",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-sdk/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/aws-sdk/node_modules/uuid": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -34844,7 +34837,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -35595,7 +35587,6 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
@@ -36072,7 +36063,6 @@
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -36735,7 +36725,6 @@
     },
     "node_modules/jmespath": {
       "version": "0.16.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
@@ -36754,7 +36743,6 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -39171,7 +39159,6 @@
     },
     "node_modules/querystring": {
       "version": "0.2.0",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -39714,7 +39701,6 @@
     },
     "node_modules/sax": {
       "version": "1.2.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/scheduler": {
@@ -40114,7 +40100,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sqlstring": {
@@ -41291,7 +41276,6 @@
     },
     "node_modules/url": {
       "version": "0.10.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
@@ -41300,7 +41284,6 @@
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/urlpattern-polyfill": {
@@ -41309,7 +41292,6 @@
     },
     "node_modules/util": {
       "version": "0.12.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -41581,7 +41563,6 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -41765,7 +41746,6 @@
     },
     "node_modules/xml2js": {
       "version": "0.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -41777,7 +41757,6 @@
     },
     "node_modules/xmlbuilder": {
       "version": "11.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -46657,7 +46636,8 @@
       "dependencies": {
         "@aws-amplify/backend": "^1.16.1",
         "@aws-amplify/backend-output-storage": "^1.3.1",
-        "@aws-amplify/platform-core": "^1.10.0"
+        "@aws-amplify/platform-core": "^1.10.0",
+        "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.189.0",

--- a/packages/create-amplify/src/default_packages.json
+++ b/packages/create-amplify/src/default_packages.json
@@ -2,7 +2,7 @@
   "defaultDevPackages": [
     "@aws-amplify/backend",
     "@aws-amplify/backend-cli",
-    "aws-cdk-lib@2.207.0",
+    "aws-cdk-lib@2.204.0",
     "constructs@^10.0.0",
     "typescript@^5.0.0",
     "tsx",

--- a/packages/rest-api-construct/package.json
+++ b/packages/rest-api-construct/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.189.0",
+    "aws-cdk-lib": "^2.189.1",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/rest-api-construct/package.json
+++ b/packages/rest-api-construct/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@aws-amplify/backend": "^1.16.1",
     "@aws-amplify/backend-output-storage": "^1.3.1",
-    "@aws-amplify/platform-core": "^1.10.0"
+    "@aws-amplify/platform-core": "^1.10.0",
+    "aws-lambda": "^1.0.7"
   }
 }

--- a/packages/rest-api-construct/package.json
+++ b/packages/rest-api-construct/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/backend": "^1.16.1",
-    "@aws-amplify/backend-output-storage": "^1.3.1"
+    "@aws-amplify/backend-output-storage": "^1.3.1",
+    "@aws-amplify/platform-core": "^1.10.0"
   }
 }

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -9,37 +9,67 @@ import {
   StackResolverStub,
 } from '@aws-amplify/backend-platform-test-stubs';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
+import assert from 'node:assert';
+import { RestApiPathConfig } from './types.js';
+
+const setupExampleLambda = (stack: Stack) => {
+  const factory = defineFunction({
+    name: 'Test Function',
+    entry: './test-assets/handler.ts',
+  });
+
+  //stubs for the instance props
+  const constructContainer = new ConstructContainerStub(
+    new StackResolverStub(stack),
+  );
+  const outputStorageStrategy = new StackMetadataBackendOutputStorageStrategy(
+    stack,
+  );
+  const resourceNameValidator = new ResourceNameValidatorStub();
+  const getInstanceProps: ConstructFactoryGetInstanceProps = {
+    constructContainer,
+    outputStorageStrategy,
+    resourceNameValidator,
+  };
+
+  return factory.getInstance(getInstanceProps);
+};
+
+const constructApiWithPath = (path: string, n: number = 1) => {
+  if (n < 0) n = 0;
+  const stack = new Stack(new App());
+  const resource = setupExampleLambda(stack);
+  if (n == 0)
+    return new RestApiConstruct(stack, 'testApi0', {
+      apiName: 'testApi0',
+      apiProps: [],
+    });
+  const apiProp: RestApiPathConfig = {
+    lambdaEntry: resource,
+    methods: [{ method: 'GET', authorizer: { type: 'none' } }],
+    path: path,
+  };
+  const apiProps: RestApiPathConfig[] = [];
+  for (let x = 0; x < n; x++) {
+    apiProps.push(apiProp);
+  }
+  return new RestApiConstruct(stack, 'testApi1', {
+    apiName: 'testApi1',
+    apiProps: apiProps,
+  });
+};
 
 void describe('RestApiConstruct Lambda Handling', () => {
   void it('integrates the result of defineFunction into the api', () => {
     const app = new App();
     const stack = new Stack(app);
-    const factory = defineFunction({
-      name: 'Test Function',
-      entry: './test-assets/handler.ts',
-    });
-
-    //stubs for the instance props
-    const constructContainer = new ConstructContainerStub(
-      new StackResolverStub(stack),
-    );
-    const outputStorageStrategy = new StackMetadataBackendOutputStorageStrategy(
-      stack,
-    );
-    const resourceNameValidator = new ResourceNameValidatorStub();
-    const getInstanceProps: ConstructFactoryGetInstanceProps = {
-      constructContainer,
-      outputStorageStrategy,
-      resourceNameValidator,
-    };
-
-    const resource = factory.getInstance(getInstanceProps);
+    const resource = setupExampleLambda(stack);
 
     new RestApiConstruct(stack, 'RestApiTest', {
       apiName: 'RestApiTest',
       apiProps: [
         {
-          path: 'items',
+          path: '/items',
           lambdaEntry: resource,
           methods: [
             {
@@ -50,6 +80,35 @@ void describe('RestApiConstruct Lambda Handling', () => {
         },
       ],
     });
+  });
+});
+
+void describe('RestApiConstruct Error Handling', () => {
+  void it('throws an error if any of the rest api paths are invalid', () => {
+    assert.throws(
+      () => constructApiWithPath('no/leading/slash'),
+      'NoLeadingSlashError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/an/ending/slash/'),
+      'TrailingSlashError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/a/double//slash'),
+      'DoubleSlashError',
+    );
+    assert.throws(() => constructApiWithPath(''), 'EmptyPathError');
+
+    assert.throws(
+      () => constructApiWithPath('/no/paths/provided', 0),
+      'NoPathsError',
+    );
+    assert.throws(
+      () => constructApiWithPath('/a/duplicate', 2),
+      'DuplicatePathError',
+    );
+
+    assert.doesNotThrow(() => constructApiWithPath('/a/valid/path'));
   });
 });
 

--- a/packages/rest-api-construct/src/construct.test.ts
+++ b/packages/rest-api-construct/src/construct.test.ts
@@ -11,6 +11,8 @@ import {
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import assert from 'node:assert';
 import { RestApiPathConfig } from './types.js';
+import { handler } from './test-assets/handler.js';
+import { Context } from 'aws-lambda';
 
 const setupExampleLambda = (stack: Stack) => {
   const factory = defineFunction({
@@ -109,6 +111,28 @@ void describe('RestApiConstruct Error Handling', () => {
     );
 
     assert.doesNotThrow(() => constructApiWithPath('/a/valid/path'));
+  });
+});
+
+void describe('Handler testing', () => {
+  void it('test function works and returns hello world', async () => {
+    const mockContext: Context = {
+      callbackWaitsForEmptyEventLoop: false,
+      functionName: 'testFunction',
+      functionVersion: '1',
+      invokedFunctionArn:
+        'arn:aws:lambda:us-east-1:123456789012:function:testFunction',
+      memoryLimitInMB: '128',
+      awsRequestId: 'testRequestId',
+      logGroupName: '/aws/lambda/testFunction',
+      logStreamName: '2021/01/01/[$LATEST]a',
+      getRemainingTimeInMillis: () => 1000,
+      done: () => {},
+      fail: () => {},
+      succeed: () => {},
+    };
+    const result = await handler(null, mockContext, () => {});
+    assert.equal(result, 'Hello, World!');
   });
 });
 

--- a/packages/rest-api-construct/src/construct.ts
+++ b/packages/rest-api-construct/src/construct.ts
@@ -45,10 +45,10 @@ export class RestApiConstruct extends Construct {
     root: apiGateway.IResource,
     path: string,
   ): apiGateway.IResource {
-    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /items/stuff/
+    //remove the leading slash to prevent empty id error
     if (path.startsWith('/')) path = path.substring(1);
-    // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
 
+    // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
     const parts = path.split('/');
 
     // Traverse the path, adding any missing nested resources along the way

--- a/packages/rest-api-construct/src/construct.ts
+++ b/packages/rest-api-construct/src/construct.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import * as apiGateway from 'aws-cdk-lib/aws-apigateway';
 import { RestApiConstructProps } from './types.js';
+import { validateRestApiPaths } from './validate_paths.js';
 
 /**
  * Rest API construct for Amplify Backend
@@ -12,6 +13,11 @@ export class RestApiConstruct extends Construct {
    */
   constructor(scope: Construct, id: string, props: RestApiConstructProps) {
     super(scope, id);
+
+    //check that the paths are valid before creating the API
+    const paths: string[] = [];
+    props.apiProps.forEach((value) => paths.push(value.path));
+    validateRestApiPaths(paths);
 
     // Create a new API Gateway REST API with the specified name
     this.api = new apiGateway.RestApi(this, 'RestApi', {
@@ -39,8 +45,10 @@ export class RestApiConstruct extends Construct {
     root: apiGateway.IResource,
     path: string,
   ): apiGateway.IResource {
-    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /
+    //TODO: remove leading/trailing slashes from path and check it is not an empty string? eg /items, items/stuff/, /items/stuff/
+    if (path.startsWith('/')) path = path.substring(1);
     // Split the path into parts (e.g. "posts/comments" → ["posts", "comments"])
+
     const parts = path.split('/');
 
     // Traverse the path, adding any missing nested resources along the way

--- a/packages/rest-api-construct/src/validate_paths.ts
+++ b/packages/rest-api-construct/src/validate_paths.ts
@@ -1,0 +1,57 @@
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+
+/**
+ * Validates REST API paths, ensuring a leading slash, no trailing slash, and no double slashes.
+ * If all paths are valid, nothing will happen; otherwise an error will be thrown.
+ * @param paths array of all the paths to be validated
+ */
+export const validateRestApiPaths = (paths: string[]) => {
+  if (paths.length == 0) {
+    throw new AmplifyUserError<string>('NoPathsError', {
+      message: 'There must be at least one path.',
+      resolution: 'Add at least one valid path.',
+    });
+  }
+  const pathCount: { [path: string]: number } = {};
+  paths.forEach((value) => {
+    validatePath(value);
+    if (pathCount[value]) {
+      throw new AmplifyUserError<string>('DuplicatePathError', {
+        message:
+          'Rest API paths must be unique. Found duplicate path: ' + value,
+        resolution: 'Remove duplicates of the path, leaving only one.',
+      });
+    } else {
+      pathCount[value] = 1;
+    }
+  });
+};
+
+const validatePath = (path: string) => {
+  if (path === '') {
+    throw new AmplifyUserError<string>('EmptyPathError', {
+      message: 'A path must not be an empty string.',
+      resolution: 'Replace any empty string paths with valid paths.',
+    });
+  }
+  if (!path.startsWith('/')) {
+    throw new AmplifyUserError<string>('NoLeadingSlashError', {
+      message: "Rest API paths must start with '/'. Found path: " + path,
+      resolution: "Add '/' to the start of your path.",
+    });
+  }
+
+  if (path.endsWith('/')) {
+    throw new AmplifyUserError<string>('TrailingSlashError', {
+      message: "Rest API paths must not end with '/'. Found path: " + path,
+      resolution: "Remove '/' from the end of your path.",
+    });
+  }
+
+  if (path.includes('//')) {
+    throw new AmplifyUserError<string>('DoubleSlashError', {
+      message: "Rest API paths must not contain '//'. Found path: " + path,
+      resolution: "Replace '//' with '/' in your path.",
+    });
+  }
+};

--- a/packages/rest-api-construct/tsconfig.json
+++ b/packages/rest-api-construct/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
     { "path": "../backend" },
-    { "path": "../backend-output-storage" }
+    { "path": "../backend-output-storage" },
+    { "path": "../platform-core" }
   ]
 }


### PR DESCRIPTION
## Changes
Updates peer dependency aws-cdk-lib from 2.189.0 to 2.189.1, now passes test_with_baseline_dependencies
Contains changes from previous PRs, but effective changes are just package-lock and package

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
